### PR TITLE
Some bug fixes and feature additions

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,7 @@
+rm -rf build
+mkdir build
+meson build
+meson configure build -Ddebug=false -Doptimization=2
+cd build
+ninja
+cp ../assets assets -r

--- a/make_release.sh
+++ b/make_release.sh
@@ -5,7 +5,7 @@ meson configure build -Ddebug=false -Doptimization=2
 cd build
 ninja
 cp ../assets assets -r
-cp -t . /mingw64/bin/libbrotlidec.dll /mingw64/bin/libharfbuzz-0.dll /mingw64/bin/libpng16-16.dll /mingw64/bin/libvorbis-0.dll /mingw64/bin/zlib1.dll /mingw64/bin/libbz2-1.dll /mingw64/bin/libiconv-2.dll /mingw64/bin/libsfml-audio-2.dll /mingw64/bin/libvorbisenc-2.dll /mingw64/bin/libfreetype-6.dll /mingw64/bin/libintl-8.dll /mingw64/bin/libsfml-graphics-2.dll /mingw64/bin/libvorbisfile-3.dll /mingw64/bin/libgcc_s_seh-1.dll /mingw64/bin/libogg-0.dll /mingw64/bin/libsfml-system-2.dll /mingw64/bin/libwinpthread-1.dll /mingw64/bin/libFLAC-8.dll /mingw64/bin/libglib-2.0-0.dll /mingw64/bin/libopenal-1.dll /mingw64/bin/libsfml-window-2.dll /mingw64/bin/libbrotlicommon.dll /mingw64/bin/libgraphite2.dll /mingw64/bin/libpcre-1.dll /mingw64/bin/libstdc++-6.dll
+../utils/copy_dependencies.py -f jujube.exe
 
 rm -rf jujube@exe meson* build.ninja .ninja* compile_commands.json test
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,7 +1,7 @@
 rm -rf build
 mkdir build
 meson build
-meson configure build -Ddebug=false -Doptimization=2
+meson configure build -Ddebug=false -Doptimization=2 
 cd build
 ninja
 cp ../assets assets -r

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,0 +1,11 @@
+mkdir release
+meson release
+cd release
+ninja
+cp ../assets assets -r
+cp -t . /mingw64/bin/libbrotlidec.dll /mingw64/bin/libharfbuzz-0.dll /mingw64/bin/libpng16-16.dll /mingw64/bin/libvorbis-0.dll /mingw64/bin/zlib1.dll /mingw64/bin/libbz2-1.dll /mingw64/bin/libiconv-2.dll /mingw64/bin/libsfml-audio-2.dll /mingw64/bin/libvorbisenc-2.dll /mingw64/bin/libfreetype-6.dll /mingw64/bin/libintl-8.dll /mingw64/bin/libsfml-graphics-2.dll /mingw64/bin/libvorbisfile-3.dll /mingw64/bin/libgcc_s_seh-1.dll /mingw64/bin/libogg-0.dll /mingw64/bin/libsfml-system-2.dll /mingw64/bin/libwinpthread-1.dll /mingw64/bin/libFLAC-8.dll /mingw64/bin/libglib-2.0-0.dll /mingw64/bin/libopenal-1.dll /mingw64/bin/libsfml-window-2.dll /mingw64/bin/libbrotlicommon.dll /mingw64/bin/libgraphite2.dll /mingw64/bin/libpcre-1.dll /mingw64/bin/libstdc++-6.dll
+
+rm -rf jujube@exe meson* build.ninja .ninja* compile_commands.json test
+
+cd ..
+zip jujube.zip -r release

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,6 +1,7 @@
-mkdir release
-meson release
-cd release
+rm -rf build
+mkdir build
+meson build
+cd build
 ninja
 cp ../assets assets -r
 cp -t . /mingw64/bin/libbrotlidec.dll /mingw64/bin/libharfbuzz-0.dll /mingw64/bin/libpng16-16.dll /mingw64/bin/libvorbis-0.dll /mingw64/bin/zlib1.dll /mingw64/bin/libbz2-1.dll /mingw64/bin/libiconv-2.dll /mingw64/bin/libsfml-audio-2.dll /mingw64/bin/libvorbisenc-2.dll /mingw64/bin/libfreetype-6.dll /mingw64/bin/libintl-8.dll /mingw64/bin/libsfml-graphics-2.dll /mingw64/bin/libvorbisfile-3.dll /mingw64/bin/libgcc_s_seh-1.dll /mingw64/bin/libogg-0.dll /mingw64/bin/libsfml-system-2.dll /mingw64/bin/libwinpthread-1.dll /mingw64/bin/libFLAC-8.dll /mingw64/bin/libglib-2.0-0.dll /mingw64/bin/libopenal-1.dll /mingw64/bin/libsfml-window-2.dll /mingw64/bin/libbrotlicommon.dll /mingw64/bin/libgraphite2.dll /mingw64/bin/libpcre-1.dll /mingw64/bin/libstdc++-6.dll
@@ -8,4 +9,5 @@ cp -t . /mingw64/bin/libbrotlidec.dll /mingw64/bin/libharfbuzz-0.dll /mingw64/bi
 rm -rf jujube@exe meson* build.ninja .ninja* compile_commands.json test
 
 cd ..
-zip jujube.zip -r release
+zip jujube.zip -r build
+mv -t ../ jujube.zip

--- a/make_release.sh
+++ b/make_release.sh
@@ -10,4 +10,4 @@ rm -rf jujube@exe meson* build.ninja .ninja* compile_commands.json test
 
 cd ..
 zip jujube.zip -r build
-mv -t ../ jujube.zip
+mv -t build jujube.zip

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,6 +1,7 @@
 rm -rf build
 mkdir build
 meson build
+meson configure build -Ddebug=false -Doptimization=2
 cd build
 ninja
 cp ../assets assets -r

--- a/src/Data/GradedNote.cpp
+++ b/src/Data/GradedNote.cpp
@@ -47,4 +47,23 @@ namespace Data {
             return Judgement::Miss;
         }
     }
+    // implement the strange way in which jubeat judges hold note releases 
+    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time note_duration, const int tail_length) {
+        int error_margin = 60; 
+        // take the length of the note in ticks on a 300 hz clock and divide by length of tail in pixels
+        // logic taken from reversing the game's timing code
+        double milliseconds_to_300hz = 0.3;
+        int adjusted_note_duration = (int) (note_duration.asMilliseconds() * milliseconds_to_300hz) - 
+                                    (error_margin * (double) ((note_duration.asMilliseconds() 
+                                    * milliseconds_to_300hz) / (tail_length*195)));
+        if( (duration_held.asMilliseconds() * milliseconds_to_300hz) >= adjusted_note_duration) // done
+            return Judgement::Perfect;
+        int percentage_held = (duration_held.asMilliseconds() * milliseconds_to_300hz / adjusted_note_duration) * 100;
+        if (percentage_held < 100 || percentage_held >= 81)
+            return Judgement::Great;
+        else if (percentage_held < 80 || percentage_held >= 51)
+            return Judgement::Good;
+        else 
+            return Judgement::Poor;
+    }
 }

--- a/src/Data/GradedNote.cpp
+++ b/src/Data/GradedNote.cpp
@@ -48,7 +48,7 @@ namespace Data {
         }
     }
     // implement the strange way in which jubeat judges hold note releases 
-    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time note_duration, const int tail_length) {
+    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time& note_duration, const int tail_length) {
         int error_margin = 60; 
         // take the length of the note in ticks on a 300 hz clock and divide by length of tail in pixels
         // logic taken from reversing the game's timing code
@@ -56,12 +56,12 @@ namespace Data {
         int adjusted_note_duration = (int) (note_duration.asMilliseconds() * milliseconds_to_300hz) - 
                                     (error_margin * (double) ((note_duration.asMilliseconds() 
                                     * milliseconds_to_300hz) / (tail_length*195)));
-        if( (duration_held.asMilliseconds() * milliseconds_to_300hz) >= adjusted_note_duration) // done
+        if((duration_held.asMilliseconds() * milliseconds_to_300hz) >= adjusted_note_duration) // done
             return Judgement::Perfect;
         int percentage_held = (duration_held.asMilliseconds() * milliseconds_to_300hz / adjusted_note_duration) * 100;
-        if (percentage_held < 100 || percentage_held >= 81)
+        if (percentage_held < 100 and percentage_held >= 81)
             return Judgement::Great;
-        else if (percentage_held < 80 || percentage_held >= 51)
+        else if (percentage_held < 80 and percentage_held >= 51)
             return Judgement::Good;
         else 
             return Judgement::Poor;

--- a/src/Data/GradedNote.cpp
+++ b/src/Data/GradedNote.cpp
@@ -35,11 +35,11 @@ namespace Data {
         if (delta_abs < sf::Time::Zero) {
             delta_abs = -delta_abs;
         }
-        if (delta_abs < sf::milliseconds(42)) {
+        if (delta_abs < sf::milliseconds(40)) {
             return Judgement::Perfect;
-        } else if (delta_abs < sf::milliseconds(82)) {
+        } else if (delta_abs < sf::milliseconds(80)) {
             return Judgement::Great;
-        } else if (delta_abs < sf::milliseconds(162)) {
+        } else if (delta_abs < sf::milliseconds(160)) {
             return Judgement::Good;
         } else if (delta_abs < sf::milliseconds(533)) {
             return Judgement::Poor;

--- a/src/Data/GradedNote.cpp
+++ b/src/Data/GradedNote.cpp
@@ -49,6 +49,7 @@ namespace Data {
     }
     // implement the strange way in which jubeat judges hold note releases 
     Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time& note_duration, const int tail_length) {
+        // if we implement hard mode we'll need a cleaner implementation of this since this would be 30. works for now though
         int error_margin = 60; 
         // take the length of the note in ticks on a 300 hz clock and divide by length of tail in pixels
         // logic taken from reversing the game's timing code

--- a/src/Data/GradedNote.cpp
+++ b/src/Data/GradedNote.cpp
@@ -54,17 +54,26 @@ namespace Data {
         // take the length of the note in ticks on a 300 hz clock and divide by length of tail in pixels
         // logic taken from reversing the game's timing code
         double milliseconds_to_300hz = 0.3;
-        int adjusted_note_duration = (int) (note_duration.asMilliseconds() * milliseconds_to_300hz) - 
-                                    (error_margin * (double) ((note_duration.asMilliseconds() 
-                                    * milliseconds_to_300hz) / (tail_length*195)));
-        if((duration_held.asMilliseconds() * milliseconds_to_300hz) >= adjusted_note_duration) // done
+        auto note_duration_300hz = static_cast<double>(note_duration.asMilliseconds()) * milliseconds_to_300hz;
+        auto adjusted_note_duration = static_cast<int>(
+            note_duration_300hz * (1 - (static_cast<double>(error_margin) / (tail_length*195)))
+        );
+
+        // held for longer than duration : done
+        if((duration_held.asMilliseconds() * milliseconds_to_300hz) >= adjusted_note_duration) {
             return Judgement::Perfect;
-        int percentage_held = (duration_held.asMilliseconds() * milliseconds_to_300hz / adjusted_note_duration) * 100;
-        if (percentage_held < 100 and percentage_held >= 81)
+        }
+
+        auto percentage_held = static_cast<int>(
+            duration_held.asMilliseconds() * milliseconds_to_300hz / adjusted_note_duration * 100
+        );
+
+        if (percentage_held < 100 and percentage_held >= 81) {
             return Judgement::Great;
-        else if (percentage_held < 80 and percentage_held >= 51)
+        } else if (percentage_held < 80 and percentage_held >= 51) {
             return Judgement::Good;
-        else 
+        } else {
             return Judgement::Poor;
+        }
     }
 }

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -14,6 +14,8 @@ namespace Data {
         Good,
         Poor,
         Miss,
+        Early,
+        Late
     };
 
     bool judgement_breaks_combo(Judgement j);
@@ -26,6 +28,7 @@ namespace Data {
         TimedJudgement() : delta(sf::Time::Zero), judgement(Judgement::Miss) {};
         TimedJudgement(const sf::Time& d, const Judgement& j) : delta(d), judgement(j) {};
         explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
+        //explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
         sf::Time delta = sf::Time::Zero;
         Judgement judgement = Judgement::Miss;
     };

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -13,9 +13,7 @@ namespace Data {
         Great,
         Good,
         Poor,
-        Miss,
-        Early,
-        Late
+        Miss
     };
 
     bool judgement_breaks_combo(Judgement j);

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -27,10 +27,15 @@ namespace Data {
         TimedJudgement() : delta(sf::Time::Zero), judgement(Judgement::Miss) {};
         TimedJudgement(const sf::Time& d, const Judgement& j) : delta(d), judgement(j) {};
         explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
-        explicit TimedJudgement(const sf::Time& duration_held,
-                                const sf::Time& t, 
-                                const sf::Time& duration,
-                                const int tail_length) : delta(t), judgement(release_to_judgement(duration_held, duration, tail_length)) {};
+        explicit TimedJudgement(
+            const sf::Time& duration_held,
+            const sf::Time& t,
+            const sf::Time& duration,
+            const int tail_length
+        ) :
+            delta(t),
+            judgement(release_to_judgement(duration_held, duration, tail_length))
+        {};
         sf::Time delta = sf::Time::Zero;
         Judgement judgement = Judgement::Miss;
     };

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -23,7 +23,7 @@ namespace Data {
     Resources::MarkerAnimation judgement_to_animation(Judgement j);
 
     Judgement delta_to_judgement(const sf::Time& delta);
-    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time note_duration, const int tail_length);
+    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time& note_duration, const int tail_length);
 
     struct TimedJudgement {
         TimedJudgement() : delta(sf::Time::Zero), judgement(Judgement::Miss) {};
@@ -31,7 +31,7 @@ namespace Data {
         explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
         explicit TimedJudgement(const sf::Time& duration_held,
                                 const sf::Time& t, 
-                                const sf::Time duration,
+                                const sf::Time& duration,
                                 const int tail_length) : delta(t), judgement(release_to_judgement(duration_held, duration, tail_length)) {};
         sf::Time delta = sf::Time::Zero;
         Judgement judgement = Judgement::Miss;

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -13,7 +13,7 @@ namespace Data {
         Great,
         Good,
         Poor,
-        Miss
+        Miss,
     };
 
     bool judgement_breaks_combo(Judgement j);

--- a/src/Data/GradedNote.hpp
+++ b/src/Data/GradedNote.hpp
@@ -23,12 +23,16 @@ namespace Data {
     Resources::MarkerAnimation judgement_to_animation(Judgement j);
 
     Judgement delta_to_judgement(const sf::Time& delta);
+    Judgement release_to_judgement(const sf::Time& duration_held, const sf::Time note_duration, const int tail_length);
 
     struct TimedJudgement {
         TimedJudgement() : delta(sf::Time::Zero), judgement(Judgement::Miss) {};
         TimedJudgement(const sf::Time& d, const Judgement& j) : delta(d), judgement(j) {};
         explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
-        //explicit TimedJudgement(const sf::Time& t) : delta(t), judgement(delta_to_judgement(t)) {};
+        explicit TimedJudgement(const sf::Time& duration_held,
+                                const sf::Time& t, 
+                                const sf::Time duration,
+                                const int tail_length) : delta(t), judgement(release_to_judgement(duration_held, duration, tail_length)) {};
         sf::Time delta = sf::Time::Zero;
         Judgement judgement = Judgement::Miss;
     };

--- a/src/Data/Score.cpp
+++ b/src/Data/Score.cpp
@@ -97,6 +97,8 @@ namespace Data {
         case Judgement::Miss:
             shutter_delta = shutter_decrement_4x;
             break;
+        default:
+            break;
         }
         shutter = std::clamp(shutter+shutter_delta, 0, 1024);
     }

--- a/src/Data/Score.cpp
+++ b/src/Data/Score.cpp
@@ -36,6 +36,10 @@ namespace Data {
         return shutter;
     }
 
+    int ClassicScore::get_judgement_counts(Judgement j) const {
+        return judgement_counts.at(j);
+    }
+
     int ClassicScore::get_final_score() const {
         return get_score() + shutter*100000/1024;
     }

--- a/src/Data/Score.hpp
+++ b/src/Data/Score.hpp
@@ -51,6 +51,8 @@ namespace Data {
         virtual Rating get_rating() const = 0;
         // Update score according to the recieved judgement
         virtual void update(Judgement j) = 0;
+        // Get judgments
+        virtual int get_judgement_counts(Judgement j) const = 0;
     };
 
     std::size_t count_classic_scoring_events(const std::set<Note>& notes);
@@ -64,6 +66,7 @@ namespace Data {
         int get_score() const override;
         Rating get_rating() const override;
         void update(Judgement j) override;
+        int get_judgement_counts(Judgement j) const;
     private:
         int shutter = 0;
         int shutter_incerment_2x;
@@ -71,7 +74,6 @@ namespace Data {
         int shutter_decrement_4x;
         const std::size_t tap_event_count;
         std::unordered_map<Judgement, std::size_t> judgement_counts;
-
         friend class Gameplay::Screen;
     };
 }

--- a/src/Drawables/GradedDensityGraph.cpp
+++ b/src/Drawables/GradedDensityGraph.cpp
@@ -11,6 +11,7 @@ namespace Drawables {
         switch (judge) {
         case Data::Judgement::Perfect:
             return DensityLineGrade::Perfect;
+        case Data::Judgement::Good:
         case Data::Judgement::Great:
             return DensityLineGrade::Great;
         default:

--- a/src/Drawables/GradedDensityGraph.cpp
+++ b/src/Drawables/GradedDensityGraph.cpp
@@ -11,8 +11,8 @@ namespace Drawables {
         switch (judge) {
         case Data::Judgement::Perfect:
             return DensityLineGrade::Perfect;
-        case Data::Judgement::Good:
         case Data::Judgement::Great:
+        case Data::Judgement::Good:
             return DensityLineGrade::Great;
         default:
             return DensityLineGrade::ComboBreak;

--- a/src/Screens/Gameplay/Gameplay.cpp
+++ b/src/Screens/Gameplay/Gameplay.cpp
@@ -596,7 +596,7 @@ namespace Gameplay {
             return;
         }
     }
-    // TODO: FIX RELEASE TIMING CODE
+
     void Screen::handle_button_release(const Input::Button& button, const sf::Time& music_time) {
         for (auto&& note_ref : visible_notes) {
             auto& note = note_ref.get();
@@ -616,7 +616,9 @@ namespace Gameplay {
             if (note.long_release) {
                 continue;
             }
-            auto timed_judgement = Data::TimedJudgement{music_time-note.timing-note.duration};
+            auto timed_judgement = Data::TimedJudgement{music_time-note.timing, 
+                                                        music_time-note.timing-note.duration, 
+                                                        note.duration, note.get_tail_length()};
             note.long_release = timed_judgement;
             score.update(timed_judgement.judgement);
             graded_density_graph.update_grades(timed_judgement.judgement, note.timing+note.duration);

--- a/src/Screens/Gameplay/Gameplay.cpp
+++ b/src/Screens/Gameplay/Gameplay.cpp
@@ -611,9 +611,12 @@ namespace Gameplay {
             if (note.long_release) {
                 continue;
             }
-            auto timed_judgement = Data::TimedJudgement{music_time-note.timing, 
-                                                        music_time-note.timing-note.duration, 
-                                                        note.duration, note.get_tail_length()};
+            auto timed_judgement = Data::TimedJudgement{
+                music_time-note.timing, 
+                music_time-note.timing-note.duration, 
+                note.duration,
+                note.get_tail_length()
+            };
             note.long_release = timed_judgement;
             score.update(timed_judgement.judgement);
             graded_density_graph.update_grades(timed_judgement.judgement, note.timing+note.duration);

--- a/src/Screens/Gameplay/Gameplay.cpp
+++ b/src/Screens/Gameplay/Gameplay.cpp
@@ -576,11 +576,6 @@ namespace Gameplay {
             note = Data::GradedNote{note, music_time-note.timing};
             auto& judgement = note.tap_judgement->judgement;
             score.update(judgement);
-            // Late/early
-            if((music_time-note.timing > sf::milliseconds(0)) && note.tap_judgement->judgement != Data::Judgement::Perfect)
-                score.update(Data::Judgement::Late);
-            if((music_time-note.timing < sf::milliseconds(0)) && note.tap_judgement->judgement != Data::Judgement::Perfect)
-                score.update(Data::Judgement::Early);
             graded_density_graph.update_grades(judgement, note.timing);
             if (Data::judgement_breaks_combo(judgement)) {
                 // If we've broken combo at the begining of a long we also missed the end

--- a/src/Screens/Gameplay/Gameplay.cpp
+++ b/src/Screens/Gameplay/Gameplay.cpp
@@ -576,6 +576,11 @@ namespace Gameplay {
             note = Data::GradedNote{note, music_time-note.timing};
             auto& judgement = note.tap_judgement->judgement;
             score.update(judgement);
+            // Late/early
+            if((music_time-note.timing > sf::milliseconds(0)) && note.tap_judgement->judgement != Data::Judgement::Perfect)
+                score.update(Data::Judgement::Late);
+            if((music_time-note.timing < sf::milliseconds(0)) && note.tap_judgement->judgement != Data::Judgement::Perfect)
+                score.update(Data::Judgement::Early);
             graded_density_graph.update_grades(judgement, note.timing);
             if (Data::judgement_breaks_combo(judgement)) {
                 // If we've broken combo at the begining of a long we also missed the end
@@ -591,7 +596,7 @@ namespace Gameplay {
             return;
         }
     }
-
+    // TODO: FIX RELEASE TIMING CODE
     void Screen::handle_button_release(const Input::Button& button, const sf::Time& music_time) {
         for (auto&& note_ref : visible_notes) {
             auto& note = note_ref.get();

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -112,7 +112,7 @@ namespace Results {
             window.draw(rating_text);
 
             // Draw Judgement Breakdown
-            auto judgement_counts = new int[5];
+            std::array<int, 5> judgement_counts;
             judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
             judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
             judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -118,8 +118,8 @@ namespace Results {
             judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
             judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
             judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
-            judgement_counts[5] = score.get_judgement_counts(Data::Judgement::Late);
-            judgement_counts[6] = score.get_judgement_counts(Data::Judgement::Early);
+            judgement_counts[5] = score.get_judgement_counts(Data::Judgement::Early);
+            judgement_counts[6] = score.get_judgement_counts(Data::Judgement::Late);
 
             sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
@@ -129,8 +129,8 @@ namespace Results {
                                                 "\nGood: " + std::to_string(judgement_counts[2]) + 
                                                 "\nPoor: " + std::to_string(judgement_counts[3]) + 
                                                 "\nMiss: " + std::to_string(judgement_counts[4]) +
-                                                "\nLate: " + std::to_string(judgement_counts[5]) +
-                                                "\nEarly: "+ std::to_string(judgement_counts[6]);
+                                                "\nEarly: " + std::to_string(judgement_counts[5]) +
+                                                "\nLate: "+ std::to_string(judgement_counts[6]);
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
             Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -111,6 +111,32 @@ namespace Results {
             );
             window.draw(rating_text);
 
+            // Draw Judgement Breakdown
+            std::array<int, 5> judgement_counts;
+            judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
+            judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
+            judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
+            judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
+            judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
+
+            sf::Text judgements;
+            judgements.setFont(shared.fallback_font.black);
+            judgements.setFillColor(sf::Color(29, 98, 226));
+            std::string judgement_to_string =   "Perfect: " + std::to_string(judgement_counts[0]) + 
+                                                "\nGreat: " + std::to_string(judgement_counts[1]) + 
+                                                "\nGood: " + std::to_string(judgement_counts[2]) + 
+                                                "\nPoor: " + std::to_string(judgement_counts[3]) + 
+                                                "\nMiss: " + std::to_string(judgement_counts[4]);
+            judgements.setString(judgement_to_string);
+            judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
+            Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);
+            judgements.setPosition(
+                get_ribbon_x()+0.f*get_panel_step()+0.5*get_panel_size(),
+                get_ribbon_y()+2.f*get_panel_step()+0.5*get_panel_size()
+            );
+            window.draw(judgements);
+
+
             // Draw song info
             auto song_title = song_selection.song.title;
             if (not song_title.empty()) {

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -112,12 +112,15 @@ namespace Results {
             window.draw(rating_text);
 
             // Draw Judgement Breakdown
-            std::array<int, 5> judgement_counts;
+            std::array<int, 7> judgement_counts;
             judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
             judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
             judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
             judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
             judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
+            judgement_counts[5] = score.get_judgement_counts(Data::Judgement::Late);
+            judgement_counts[6] = score.get_judgement_counts(Data::Judgement::Early);
+
             sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
             judgements.setFillColor(sf::Color(29, 98, 226));
@@ -125,7 +128,9 @@ namespace Results {
                                                 "\nGreat: " + std::to_string(judgement_counts[1]) + 
                                                 "\nGood: " + std::to_string(judgement_counts[2]) + 
                                                 "\nPoor: " + std::to_string(judgement_counts[3]) + 
-                                                "\nMiss: " + std::to_string(judgement_counts[4]);
+                                                "\nMiss: " + std::to_string(judgement_counts[4]) +
+                                                "\nLate: " + std::to_string(judgement_counts[5]) +
+                                                "\nEarly: "+ std::to_string(judgement_counts[6]);
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
             Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -112,21 +112,15 @@ namespace Results {
             window.draw(rating_text);
 
             // Draw Judgement Breakdown
-            std::array<int, 5> judgement_counts;
-            judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
-            judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
-            judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
-            judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
-            judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
-
-            sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
             judgements.setFillColor(sf::Color(29, 98, 226));
-            std::string judgement_to_string =   "Perfect: " + std::to_string(judgement_counts[0]) + 
-                                                "\nGreat: " + std::to_string(judgement_counts[1]) + 
-                                                "\nGood: " + std::to_string(judgement_counts[2]) + 
-                                                "\nPoor: " + std::to_string(judgement_counts[3]) + 
-                                                "\nMiss: " + std::to_string(judgement_counts[4]);
+            std::string judgement_to_string = (
+                "Perfect: " + std::to_string(score.get_judgement_counts(Data::Judgement::Perfect)) + "\n" +
+                "Great: " + std::to_string(score.get_judgement_counts(Data::Judgement::Great)) + "\n" +
+                "Good: " + std::to_string(score.get_judgement_counts(Data::Judgement::Good)) + "\n" +
+                "Poor: " + std::to_string(score.get_judgement_counts(Data::Judgement::Poor)) + "\n" +
+                "Miss: " + std::to_string(score.get_judgement_counts(Data::Judgement::Miss))
+            );
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
             Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -121,8 +121,11 @@ namespace Results {
             sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
             judgements.setFillColor(sf::Color(29, 98, 226));
-            std::string judgement_to_string = "Perfect: " + std::to_string(judgement_counts[0]) + "\nGreat: " + std::to_string(judgement_counts[1]) + 
-            "\nGood: " + std::to_string(judgement_counts[2]) + "\nPoor: " + std::to_string(judgement_counts[3]) + "\nMiss: " + std::to_string(judgement_counts[4]);
+            std::string judgement_to_string =   "Perfect: " + std::to_string(judgement_counts[0]) + 
+                                                "\nGreat: " + std::to_string(judgement_counts[1]) + 
+                                                "\nGood: " + std::to_string(judgement_counts[2]) + 
+                                                "\nPoor: " + std::to_string(judgement_counts[3]) + 
+                                                "\nMiss: " + std::to_string(judgement_counts[4]);
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
             Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -112,6 +112,7 @@ namespace Results {
             window.draw(rating_text);
 
             // Draw Judgement Breakdown
+            sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
             judgements.setFillColor(sf::Color(29, 98, 226));
             std::string judgement_to_string = (

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -25,6 +25,7 @@ namespace Results {
         sf::Clock imgui_clock;
         auto final_score = score.get_final_score();
         auto final_rating = score.get_rating();
+
         while ((not should_exit) and window.isOpen()) {
             sf::Event event;
             while (window.pollEvent(event)) {
@@ -53,6 +54,23 @@ namespace Results {
             }
             ImGui::SFML::Update(window, imgui_clock.restart());
             window.clear(sf::Color(7, 23, 53));
+
+            
+            // Draw song info
+            // Cover is 40x40 @ (384,20)
+            if (song_selection.song.cover) {
+                auto cover = shared.covers.get(*song_selection.song.full_cover_path());
+                if (cover) {
+                    sf::Sprite cover_sprite{*cover->texture};
+                    auto cover_size = 40.f/768.f*get_screen_width();
+                    Toolkit::set_size_from_local_bounds(cover_sprite, cover_size, cover_size);
+                    cover_sprite.setPosition(
+                        384.f/768.f*get_screen_width(),
+                        20.f/768.f*get_screen_width()
+                    );
+                    window.draw(cover_sprite);
+                }
+            }
 
             // White line under the density graph
             sf::RectangleShape line{{get_screen_width()*1.1f,2.f/768.f*get_screen_width()}};
@@ -92,6 +110,28 @@ namespace Results {
                 get_ribbon_y()+2.f*get_panel_step()+0.5*get_panel_size()
             );
             window.draw(rating_text);
+
+            // Draw Judgement Breakdown
+            auto judgement_counts = new int[5];
+            judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
+            judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
+            judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
+            judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
+            judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
+            sf::Text judgements;
+            judgements.setFont(shared.fallback_font.black);
+            judgements.setFillColor(sf::Color(29, 98, 226));
+            std::string judgement_to_string = "Perfect: " + std::to_string(judgement_counts[0]) + "\nGreat: " + std::to_string(judgement_counts[0]) + 
+            "\nGood: " + std::to_string(judgement_counts[0]) + "\nPoor: " + std::to_string(judgement_counts[3]) + "\nMiss: " + std::to_string(judgement_counts[4]);
+            judgements.setString(judgement_to_string);
+            judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
+            Toolkit::set_local_origin_normalized(judgements, 0.8f, 0.5f);
+            judgements.setPosition(
+                get_ribbon_x()+0.f*get_panel_step()+0.5*get_panel_size(),
+                get_ribbon_y()+2.f*get_panel_step()+0.5*get_panel_size()
+            );
+            window.draw(judgements);
+
 
             // Draw song info
             auto song_title = song_selection.song.title;

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -112,14 +112,12 @@ namespace Results {
             window.draw(rating_text);
 
             // Draw Judgement Breakdown
-            std::array<int, 7> judgement_counts;
+            std::array<int, 5> judgement_counts;
             judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
             judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
             judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
             judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
             judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
-            judgement_counts[5] = score.get_judgement_counts(Data::Judgement::Early);
-            judgement_counts[6] = score.get_judgement_counts(Data::Judgement::Late);
 
             sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
@@ -128,9 +126,7 @@ namespace Results {
                                                 "\nGreat: " + std::to_string(judgement_counts[1]) + 
                                                 "\nGood: " + std::to_string(judgement_counts[2]) + 
                                                 "\nPoor: " + std::to_string(judgement_counts[3]) + 
-                                                "\nMiss: " + std::to_string(judgement_counts[4]) +
-                                                "\nEarly: " + std::to_string(judgement_counts[5]) +
-                                                "\nLate: "+ std::to_string(judgement_counts[6]);
+                                                "\nMiss: " + std::to_string(judgement_counts[4]);
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
             Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -121,11 +121,11 @@ namespace Results {
             sf::Text judgements;
             judgements.setFont(shared.fallback_font.black);
             judgements.setFillColor(sf::Color(29, 98, 226));
-            std::string judgement_to_string = "Perfect: " + std::to_string(judgement_counts[0]) + "\nGreat: " + std::to_string(judgement_counts[0]) + 
-            "\nGood: " + std::to_string(judgement_counts[0]) + "\nPoor: " + std::to_string(judgement_counts[3]) + "\nMiss: " + std::to_string(judgement_counts[4]);
+            std::string judgement_to_string = "Perfect: " + std::to_string(judgement_counts[0]) + "\nGreat: " + std::to_string(judgement_counts[1]) + 
+            "\nGood: " + std::to_string(judgement_counts[2]) + "\nPoor: " + std::to_string(judgement_counts[3]) + "\nMiss: " + std::to_string(judgement_counts[4]);
             judgements.setString(judgement_to_string);
             judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
-            Toolkit::set_local_origin_normalized(judgements, 0.8f, 0.5f);
+            Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);
             judgements.setPosition(
                 get_ribbon_x()+0.f*get_panel_step()+0.5*get_panel_size(),
                 get_ribbon_y()+2.f*get_panel_step()+0.5*get_panel_size()

--- a/src/Screens/Results/Results.cpp
+++ b/src/Screens/Results/Results.cpp
@@ -111,32 +111,6 @@ namespace Results {
             );
             window.draw(rating_text);
 
-            // Draw Judgement Breakdown
-            std::array<int, 5> judgement_counts;
-            judgement_counts[0] = score.get_judgement_counts(Data::Judgement::Perfect);
-            judgement_counts[1] = score.get_judgement_counts(Data::Judgement::Great);
-            judgement_counts[2] = score.get_judgement_counts(Data::Judgement::Good);
-            judgement_counts[3] = score.get_judgement_counts(Data::Judgement::Poor);
-            judgement_counts[4] = score.get_judgement_counts(Data::Judgement::Miss);
-
-            sf::Text judgements;
-            judgements.setFont(shared.fallback_font.black);
-            judgements.setFillColor(sf::Color(29, 98, 226));
-            std::string judgement_to_string =   "Perfect: " + std::to_string(judgement_counts[0]) + 
-                                                "\nGreat: " + std::to_string(judgement_counts[1]) + 
-                                                "\nGood: " + std::to_string(judgement_counts[2]) + 
-                                                "\nPoor: " + std::to_string(judgement_counts[3]) + 
-                                                "\nMiss: " + std::to_string(judgement_counts[4]);
-            judgements.setString(judgement_to_string);
-            judgements.setCharacterSize(static_cast<unsigned int>(0.1f*get_panel_size()));
-            Toolkit::set_local_origin_normalized(judgements, 0.5f, 0.5f);
-            judgements.setPosition(
-                get_ribbon_x()+0.f*get_panel_step()+0.5*get_panel_size(),
-                get_ribbon_y()+2.f*get_panel_step()+0.5*get_panel_size()
-            );
-            window.draw(judgements);
-
-
             // Draw song info
             auto song_title = song_selection.song.title;
             if (not song_title.empty()) {

--- a/src/Screens/Results/Results.hpp
+++ b/src/Screens/Results/Results.hpp
@@ -25,7 +25,7 @@ namespace Results {
     private:
         Drawables::GradedDensityGraph graded_density_graph;
         const Data::SongDifficulty& song_selection;
-        const Data::Chart& chart;
+        const Data::Chart chart;
         const Data::AbstractScore& score;
         bool should_exit = false;
 


### PR DESCRIPTION
Hold note release judging now emulates the official game's code for this. Some visual bugs in the results screen fixed(namely the difficulty is displayed correctly and the song jacket is displayed). Judgement breakdown is also added in the results screen in a relatively hacky way that will probably be replaced once theming is implemented. 