### PR TITLE
executable on the same folder as the assets

### DIFF
--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -19,6 +19,7 @@ Regardless of the target platform the build steps are pretty much the same :
     $ ninja
     ```
     (Replacing the `{...}`s with what you chose)
+0. Copy `jujube` executable from the build folder into project is root folder.
 
 and voila !
 


### PR DESCRIPTION
jujube is compiled in meson is build folder but you can't launch Jujube from it since it's missing all dependencies needed.
just added an extra step to remember that you need to copy your freshly made executable into the project root folder where are the datas and assests